### PR TITLE
Add template to override settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
-settings.py
 
 # Flask stuff:
 instance/
@@ -90,4 +89,3 @@ bnbenv/
 
 # Rope project settings
 .ropeproject
->>>>>>> ebc2c82b0961f4a568690c8d2e53538768c010cc

--- a/beernburger/local_settings.py.template
+++ b/beernburger/local_settings.py.template
@@ -1,0 +1,16 @@
+from .settings import *
+
+# Preimenuj v local_settings.py in nadomesti s pravimi podatki
+
+SECRET_KEY = '#yjef_b317a=(o3wxx!3=jlbn=f618&e5+6ytow_9l_!ub-jjr'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'beernburger',
+        'USER': 'test_user',
+        'PASSWORD': 'test_user_pwd123',
+        'HOST': 'localhost',
+        'PORT': '',
+    }
+}

--- a/beernburger/settings.py
+++ b/beernburger/settings.py
@@ -20,20 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-def generate_secret_key(path):
-	from django.utils.crypto import get_random_string
-	chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+'
-	x = get_random_string(50, chars)
-	with open(path, 'w') as f:
-		f.write('SECRET_KEY = {0}'.format(x))
-
-try:
-	from .secret_key import SECRET_KEY
-except ImportError:
-	settings_dir = os.path.abspath(os.path.dirname(__file__))
-	generate_secret_key(os.path.join(settings_dir, 'secret_key.py'))
-	from .secret_key import SECRET_KEY
-
+SECRET_KEY = '#yjef_b317a=(o3wxx!3=jlbn=f618&e5+6ytow_9l_!ub-jjr'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True 
@@ -94,10 +81,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'beernburger',
-	'USER': 'test_user',
-	'PASSWORD': 'test_user_pwd123',
-	'HOST': 'localhost',
-	'PORT': '',
+        'USER': 'test_user',
+        'PASSWORD': 'test_user_pwd123',
+        'HOST': 'localhost',
+        'PORT': '',
     }
 }
 


### PR DESCRIPTION
Naredil sem nekaj sprememb v skladu z dobrimi praksami uporabe nastavitev v Djangu:

http://stackoverflow.com/questions/4909958/django-local-settings#14545196

Skratka, za lokalno poganjanje ni problema, če je `SECRET_KEY` javen. V produkciji pa je najbolje, če ga imaš posebej - temu je namenjena datoteka `local_settings.py`, ki je v `.gitignore`, tako da je tukaj samo vzorec. Ta uvozi vse nastavitve iz `settings.py` in nekatere nadomesti s svojimi. Seveda bodo tam tudi nastavitve baze. Javno različico potem poženeš kot običajno, za produkcijsko različico pa poženeš
```
python3 manage.py runserver --settings=beernburger.local_settings
```

Mimogrede, programi, ki pišejo programe, niso najboljša ideja - sploh v produkciji (morda tvoj program sploh ne bo imel pravice tega narediti).